### PR TITLE
using cibadmin -o constraints instead of --obj_type constraints

### DIFF
--- a/agents/mysql_prm
+++ b/agents/mysql_prm
@@ -2129,7 +2129,7 @@ fi
 # We check if there is a location constraint against this node
 # where $OCF_RESOURCE_INSTANCE should not be running here i.e.
 # -INFINITY score, if so we ignore monitor call for this node
-contrnt=$(cibadmin -t 2 --query --obj_type constraints\
+contrnt=$(cibadmin -t 2 --query -o constraints\
    |awk "/rsc=\"$OCF_RESOURCE_INSTANCE\"/,/<\/rsc_location/"\
    |awk '/score="-INFINITY"/,/<\/rule/'\
    |egrep "expression attribute=\"#uname\".*operation=\"eq\".*value=\"$HOSTNAME\"" 2> /dev/null)

--- a/agents/mysql_prm56
+++ b/agents/mysql_prm56
@@ -1939,7 +1939,7 @@ fi
 # We check if there is a location constraint against this node
 # where $OCF_RESOURCE_INSTANCE should not be running here i.e.
 # -INFINITY score, if so we ignore monitor call for this node
-contrnt=$(cibadmin --query --obj_type constraints\
+contrnt=$(cibadmin --query -o constraints\
    |awk "/<rsc_location.*\ rsc=\"($OCF_RESOURCE_INSTANCE|$glb_master_resource)\"/,/<\/rsc_location>/"\
    |awk '/score="-INFINITY"/,/<\/rule/'\
    |egrep "expression attribute=\"#uname\".*operation=\"eq\".*value=\"$HOSTNAME\"" 2> /dev/null)


### PR DESCRIPTION
--obj_type is a legacy option, removed in Pacemaker 1.1.12