### PR TITLE
add client_binary meta data.

### DIFF
--- a/agents/mysql_monitor
+++ b/agents/mysql_monitor
@@ -128,6 +128,14 @@ Password of the mysql user to connect to the local MySQL instance
 <content type="string" default="${OCF_RESKEY_password_default}" />
 </parameter>
 
+<parameter name="client_binary" unique="0">
+<longdesc lang="en">
+MySQL Client Binary path.
+</longdesc>
+<shortdesc lang="en">MySQL client binary path</shortdesc>
+<content type="string" default="${OCF_RESKEY_client_binary_default}" />
+</parameter>
+
 <parameter name="socket" unique="0">
 <longdesc lang="en">
 Unix socket to use in order to connect to MySQL on the host


### PR DESCRIPTION
OCF_RESKEY_client_binary　is not defined meta data xml.
Add client_binary to meta data xml