### PR TITLE
df command was not portable, added -P

### DIFF
--- a/agents/mysql_prm_gtid
+++ b/agents/mysql_prm_gtid
@@ -1187,7 +1187,7 @@ get_local_ip() {
 # Determine if the datadir is full or almost full, the threshold is 97%
 check_datadir_state() {
    # Get the free space of the binlogdir
-   FREE_SPC_PCT=`/bin/df $OCF_RESKEY_datadir | /bin/grep -v Filesystem \
+   FREE_SPC_PCT=`/bin/df -P $OCF_RESKEY_datadir | /bin/grep -v Filesystem \
                         | /bin/sed  -e 's/ \+/ /g' | /usr/bin/cut -d' ' -f 5 \
                         | /usr/bin/tr -d '%'`
 


### PR DESCRIPTION
This simply adds -P to the df command. For example the original command would fail like this:

```
[root@node1 ~]# df -h
Filesystem            Size  Used Avail Use% Mounted on
/dev/mapper/vg_centos6-lv_root
                       47G  3.7G   41G   9% /
[root@node1 ~]# /bin/df /var/lib/mysql | /bin/grep -v Filesystem | /bin/sed  -e 's/ \+/ /g'| /usr/bin/cut -d' ' -f 5 | /usr/bin/tr -d '%'
/dev/mapper/vg_centos6-lv_root
9
```

With -P option:

```
[root@node1 ~]# /bin/df -P /var/lib/mysql | /bin/grep -v Filesystem | /bin/sed  -e 's/ \+/ /g'| /usr/bin/cut -d' ' -f 5 | /usr/bin/tr -d '%'
9
```